### PR TITLE
DCP-3262: ELTE support: Ena File Downloader Test Fixes

### DIFF
--- a/src/main/java/uk/ac/ebi/ena/backend/service/FileDownloaderService.java
+++ b/src/main/java/uk/ac/ebi/ena/backend/service/FileDownloaderService.java
@@ -18,7 +18,6 @@
 
 package uk.ac.ebi.ena.backend.service;
 
-import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import me.tongfei.progressbar.ProgressBar;
 import me.tongfei.progressbar.ProgressBarBuilder;
@@ -45,14 +44,12 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
-import java.util.concurrent.atomic.AtomicLong;
 
 import static uk.ac.ebi.ena.app.utils.CommonUtils.getProgressBarBuilder;
 
 @Service
 @Slf4j
 public class FileDownloaderService {
-    AtomicLong verified = new AtomicLong(0), redownloading = new AtomicLong(0);
 
     private final FileDownloaderClient fileDownloaderClient;
 

--- a/src/test/java/uk/ac/ebi/ena/backend/AccessionDetailsServiceTest.java
+++ b/src/test/java/uk/ac/ebi/ena/backend/AccessionDetailsServiceTest.java
@@ -13,15 +13,14 @@ import uk.ac.ebi.ena.app.menu.enums.DownloadFormatEnum;
 import uk.ac.ebi.ena.app.menu.enums.ProtocolEnum;
 import uk.ac.ebi.ena.app.utils.CommonUtils;
 import uk.ac.ebi.ena.backend.dto.DownloadJob;
-import uk.ac.ebi.ena.backend.dto.EnaPortalResponse;
+import uk.ac.ebi.ena.backend.dto.FileDetail;
 import uk.ac.ebi.ena.backend.enums.FileDownloadStatus;
 import uk.ac.ebi.ena.backend.service.AccessionDetailsService;
-import uk.ac.ebi.ena.backend.service.EmailService;
-import uk.ac.ebi.ena.backend.service.EnaPortalService;
 import uk.ac.ebi.ena.backend.service.FileDownloaderService;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -34,13 +33,7 @@ import static org.mockito.Mockito.*;
 public class AccessionDetailsServiceTest {
 
     @Mock
-    EnaPortalService enaPortalService;
-
-    @Mock
     FileDownloaderService fileDownloaderService;
-
-    @Mock
-    EmailService emailService;
 
     @InjectMocks
     AccessionDetailsService accessionDetailsService;
@@ -50,7 +43,7 @@ public class AccessionDetailsServiceTest {
 
     String accessionList = "SRX6415696,SRX2000905,SRX6415695";
 
-   /* @Test
+    @Test
     public void testFetchAccessionAndDownloadWhenSuccess() throws ExecutionException, InterruptedException {
         //ARRANGE
         DownloadFormatEnum format = DownloadFormatEnum.READS_FASTQ;
@@ -58,50 +51,33 @@ public class AccessionDetailsServiceTest {
         DownloadJob accessionDetailsMap = CommonUtils.processAccessions(Arrays.asList(accessionList.split(",")));
         ProtocolEnum protocol = ProtocolEnum.FTP;
         String asperaLocation = null;
-        String recipientEmailId = "datasubs@ebi.ac.uk";
-        Mockito.when(enaPortalService.getPortalResponses(Mockito.anyList(), Mockito.any(DownloadFormatEnum.class), Mockito.any(ProtocolEnum.class), Mockito.any()))
-                .thenReturn(getPortalResponses());
+
+        List<FileDetail> fileDetailList = createFileDetailFtp();
+
         final Future<FileDownloadStatus> mockedFuture = Mockito.mock(Future.class);
         when(mockedFuture.get()).thenReturn(new FileDownloadStatus(0, 0, new ArrayList<>()));
         Mockito.when(fileDownloaderService.startDownload(Mockito.any(ExecutorService.class), Mockito.any(List.class),
                 Mockito.any(String.class), Mockito.any(AccessionTypeEnum.class), Mockito.any(DownloadFormatEnum.class),
                 Mockito.anyInt())).thenReturn(mockedFuture);
         //ACT
-        accessionDetailsService.doDownload(format, downloadLocation, accessionDetailsMap, protocol, asperaLocation, recipientEmailId);
+        accessionDetailsService.doDownload(format, downloadLocation, accessionDetailsMap, Collections.singletonList(fileDetailList),protocol, asperaLocation);
         //ASSERT
-        verify(enaPortalService, times(3)).getPortalResponses(Mockito.anyList(), Mockito.any(DownloadFormatEnum.class), Mockito.any(ProtocolEnum.class),
-                Mockito.any());
-
-        verify(fileDownloaderService, times(3)).startDownload(Mockito.any(ExecutorService.class), Mockito.anyList(), Mockito.any(String.class),
+        verify(fileDownloaderService, times(1)).startDownload(Mockito.any(ExecutorService.class), Mockito.anyList(), Mockito.any(String.class),
                 Mockito.any(AccessionTypeEnum.class), Mockito.any(DownloadFormatEnum.class), Mockito.anyInt());
+    }
 
+    private List<FileDetail> createFileDetailFtp() {
+        List<FileDetail> fileDetailList = new ArrayList<>();
+        FileDetail fileDetail1 = new FileDetail("SRX2000905","SRR4000583","ftp.sra.ebi.ac.uk/vol1/fastq/SRR400/003/SRR4000583/SRR4000583.fastq.gz",
+                1174738707L,"a991ce890047ffca760c6de2617b5fec",true);
+        FileDetail fileDetail2 = new FileDetail("SRX6415696","SRR9654360","ftp.sra.ebi.ac.uk/vol1/fastq/SRR965/000/SRR9654360/SRR9654360.fastq.gz",
+                14139836L,"f3611f35a977b8b82a7adcf0a28c397d",true);
+        FileDetail fileDetail3 = new FileDetail("SRX6415695","SRR9654361","ftp.sra.ebi.ac.uk/vol1/fastq/SRR965/001/SRR9654361/SRR9654361.fastq.gz",
+                15541843L,"1236b79cd93a63289841765aabacb880",true);
+        fileDetailList.add(fileDetail1);
+        fileDetailList.add(fileDetail2);
+        fileDetailList.add(fileDetail3);
 
-    }*/
-
-
-    private List<EnaPortalResponse> getPortalResponses() {
-        List<EnaPortalResponse> portalResponses = new ArrayList<>();
-        EnaPortalResponse enaPortalResponse1 = new EnaPortalResponse();
-        enaPortalResponse1.setParentId("SRX2000905");
-        enaPortalResponse1.setRecordId("SRR4000583");
-        enaPortalResponse1.setBytes("1174738707");
-        enaPortalResponse1.setUrl("ftp.sra.ebi.ac.uk/vol1/fastq/SRR400/003/SRR4000583/SRR4000583.fastq.gz");
-        enaPortalResponse1.setMd5("a991ce890047ffca760c6de2617b5fec");
-        portalResponses.add(enaPortalResponse1);
-        EnaPortalResponse enaPortalResponse2 = new EnaPortalResponse();
-        enaPortalResponse2.setParentId("SRX6415696");
-        enaPortalResponse2.setRecordId("SRR9654360");
-        enaPortalResponse2.setBytes("14139836");
-        enaPortalResponse2.setUrl("ftp.sra.ebi.ac.uk/vol1/fastq/SRR965/000/SRR9654360/SRR9654360.fastq.gz");
-        enaPortalResponse2.setMd5("f3611f35a977b8b82a7adcf0a28c397d");
-        portalResponses.add(enaPortalResponse2);
-        EnaPortalResponse enaPortalResponse3 = new EnaPortalResponse();
-        enaPortalResponse3.setParentId("SRX6415695");
-        enaPortalResponse3.setRecordId("SRR9654361");
-        enaPortalResponse3.setBytes("15541843");
-        enaPortalResponse3.setUrl("ftp.sra.ebi.ac.uk/vol1/fastq/SRR965/001/SRR9654361/SRR9654361.fastq.gz");
-        enaPortalResponse3.setMd5("1236b79cd93a63289841765aabacb880");
-        portalResponses.add(enaPortalResponse3);
-        return portalResponses;
+        return fileDetailList;
     }
 }

--- a/src/test/java/uk/ac/ebi/ena/backend/AccessionDetailsServiceTest.java
+++ b/src/test/java/uk/ac/ebi/ena/backend/AccessionDetailsServiceTest.java
@@ -60,7 +60,7 @@ public class AccessionDetailsServiceTest {
                 Mockito.any(String.class), Mockito.any(AccessionTypeEnum.class), Mockito.any(DownloadFormatEnum.class),
                 Mockito.anyInt())).thenReturn(mockedFuture);
         //ACT
-        accessionDetailsService.doDownload(format, downloadLocation, accessionDetailsMap, Collections.singletonList(fileDetailList),protocol, asperaLocation);
+        accessionDetailsService.doDownload(format, downloadLocation, accessionDetailsMap, Collections.singletonList(fileDetailList), protocol, asperaLocation);
         //ASSERT
         verify(fileDownloaderService, times(1)).startDownload(Mockito.any(ExecutorService.class), Mockito.anyList(), Mockito.any(String.class),
                 Mockito.any(AccessionTypeEnum.class), Mockito.any(DownloadFormatEnum.class), Mockito.anyInt());
@@ -68,12 +68,12 @@ public class AccessionDetailsServiceTest {
 
     private List<FileDetail> createFileDetailFtp() {
         List<FileDetail> fileDetailList = new ArrayList<>();
-        FileDetail fileDetail1 = new FileDetail("SRX2000905","SRR4000583","ftp.sra.ebi.ac.uk/vol1/fastq/SRR400/003/SRR4000583/SRR4000583.fastq.gz",
-                1174738707L,"a991ce890047ffca760c6de2617b5fec",true);
-        FileDetail fileDetail2 = new FileDetail("SRX6415696","SRR9654360","ftp.sra.ebi.ac.uk/vol1/fastq/SRR965/000/SRR9654360/SRR9654360.fastq.gz",
-                14139836L,"f3611f35a977b8b82a7adcf0a28c397d",true);
-        FileDetail fileDetail3 = new FileDetail("SRX6415695","SRR9654361","ftp.sra.ebi.ac.uk/vol1/fastq/SRR965/001/SRR9654361/SRR9654361.fastq.gz",
-                15541843L,"1236b79cd93a63289841765aabacb880",true);
+        FileDetail fileDetail1 = new FileDetail("SRX2000905", "SRR4000583", "ftp.sra.ebi.ac.uk/vol1/fastq/SRR400/003/SRR4000583/SRR4000583.fastq.gz",
+                1174738707L, "a991ce890047ffca760c6de2617b5fec", true);
+        FileDetail fileDetail2 = new FileDetail("SRX6415696", "SRR9654360", "ftp.sra.ebi.ac.uk/vol1/fastq/SRR965/000/SRR9654360/SRR9654360.fastq.gz",
+                14139836L, "f3611f35a977b8b82a7adcf0a28c397d", true);
+        FileDetail fileDetail3 = new FileDetail("SRX6415695", "SRR9654361", "ftp.sra.ebi.ac.uk/vol1/fastq/SRR965/001/SRR9654361/SRR9654361.fastq.gz",
+                15541843L, "1236b79cd93a63289841765aabacb880", true);
         fileDetailList.add(fileDetail1);
         fileDetailList.add(fileDetail2);
         fileDetailList.add(fileDetail3);

--- a/src/test/java/uk/ac/ebi/ena/backend/BackendServiceImplTest.java
+++ b/src/test/java/uk/ac/ebi/ena/backend/BackendServiceImplTest.java
@@ -5,16 +5,23 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.ac.ebi.ena.app.menu.enums.DownloadFormatEnum;
 import uk.ac.ebi.ena.app.menu.enums.ProtocolEnum;
 import uk.ac.ebi.ena.app.utils.CommonUtils;
+import uk.ac.ebi.ena.app.utils.FileUtils;
 import uk.ac.ebi.ena.backend.dto.DownloadJob;
+import uk.ac.ebi.ena.backend.dto.FileDetail;
 import uk.ac.ebi.ena.backend.service.AccessionDetailsService;
 import uk.ac.ebi.ena.backend.service.BackendServiceImpl;
+import uk.ac.ebi.ena.backend.service.EmailService;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -24,27 +31,54 @@ import static org.mockito.Mockito.verify;
 public class BackendServiceImplTest {
 
     @Mock
+    EmailService emailService;
+
+    @Mock
     AccessionDetailsService accessionDetailsService;
 
     @InjectMocks
     BackendServiceImpl backendService;
 
-   /* @Test
+    @Test
     public void startDownloadTest() {
         //ARRANGE
         String accessionList = "SRX6415696,SRX2000905,SRX6415695";
         DownloadFormatEnum format = DownloadFormatEnum.READS_FASTQ;
         String location = System.getProperty("user.home");
-        ;
+        List<FileDetail> fileDetailList = createFileDetailFtp();
+
         DownloadJob accessionDetailsMap = CommonUtils.processAccessions(Arrays.asList(accessionList.split(",")));
         ProtocolEnum protocol = ProtocolEnum.FTP;
         String asperaConnectLocation = null;
         String emailId = "datasubs@ebi.ac.uk";
+        Mockito.when(accessionDetailsService.fetchFileDetails(format,accessionDetailsMap,protocol))
+                .thenReturn(Collections.singletonList(fileDetailList));
+        Mockito.doNothing().when(emailService).sendEmailForFastqSubmitted(Mockito.anyString(),Mockito.anyLong(),Mockito.anyLong()
+        ,Mockito.anyString(),Mockito.anyString(),Mockito.any(DownloadFormatEnum.class),Mockito.anyString());
         //ACT
         backendService.startDownload(format, location, accessionDetailsMap, protocol, asperaConnectLocation, emailId);
         //ASSERT
-        verify(accessionDetailsService, times(1)).doDownload(format, location, accessionDetailsMap, protocol, asperaConnectLocation, emailId);
+        verify(accessionDetailsService, times(1)).doDownload(format, location, accessionDetailsMap,
+                Collections.singletonList(fileDetailList),protocol, asperaConnectLocation);
 
-    }*/
+        verify(emailService,times(1)).sendEmailForFastqSubmitted(emailId,3,0,
+                FileUtils.getScriptPath(accessionDetailsMap, format),accessionDetailsMap.getAccessionField(), format, location);
+
+    }
+
+    private List<FileDetail> createFileDetailFtp() {
+        List<FileDetail> fileDetailList = new ArrayList<>();
+        FileDetail fileDetail1 = new FileDetail("SRX2000905","SRR4000583","ftp.sra.ebi.ac.uk/vol1/fastq/SRR400/003/SRR4000583/SRR4000583.fastq.gz",
+                1174738707L,"a991ce890047ffca760c6de2617b5fec",true);
+        FileDetail fileDetail2 = new FileDetail("SRX6415696","SRR9654360","ftp.sra.ebi.ac.uk/vol1/fastq/SRR965/000/SRR9654360/SRR9654360.fastq.gz",
+                14139836L,"f3611f35a977b8b82a7adcf0a28c397d",true);
+        FileDetail fileDetail3 = new FileDetail("SRX6415695","SRR9654361","ftp.sra.ebi.ac.uk/vol1/fastq/SRR965/001/SRR9654361/SRR9654361.fastq.gz",
+                15541843L,"1236b79cd93a63289841765aabacb880",true);
+        fileDetailList.add(fileDetail1);
+        fileDetailList.add(fileDetail2);
+        fileDetailList.add(fileDetail3);
+
+        return fileDetailList;
+    }
 
 }

--- a/src/test/java/uk/ac/ebi/ena/backend/BackendServiceImplTest.java
+++ b/src/test/java/uk/ac/ebi/ena/backend/BackendServiceImplTest.java
@@ -51,29 +51,29 @@ public class BackendServiceImplTest {
         ProtocolEnum protocol = ProtocolEnum.FTP;
         String asperaConnectLocation = null;
         String emailId = "datasubs@ebi.ac.uk";
-        Mockito.when(accessionDetailsService.fetchFileDetails(format,accessionDetailsMap,protocol))
+        Mockito.when(accessionDetailsService.fetchFileDetails(format, accessionDetailsMap, protocol))
                 .thenReturn(Collections.singletonList(fileDetailList));
-        Mockito.doNothing().when(emailService).sendEmailForFastqSubmitted(Mockito.anyString(),Mockito.anyLong(),Mockito.anyLong()
-        ,Mockito.anyString(),Mockito.anyString(),Mockito.any(DownloadFormatEnum.class),Mockito.anyString());
+        Mockito.doNothing().when(emailService).sendEmailForFastqSubmitted(Mockito.anyString(), Mockito.anyLong(), Mockito.anyLong()
+                , Mockito.anyString(), Mockito.anyString(), Mockito.any(DownloadFormatEnum.class), Mockito.anyString());
         //ACT
         backendService.startDownload(format, location, accessionDetailsMap, protocol, asperaConnectLocation, emailId);
         //ASSERT
         verify(accessionDetailsService, times(1)).doDownload(format, location, accessionDetailsMap,
-                Collections.singletonList(fileDetailList),protocol, asperaConnectLocation);
+                Collections.singletonList(fileDetailList), protocol, asperaConnectLocation);
 
-        verify(emailService,times(1)).sendEmailForFastqSubmitted(emailId,3,0,
-                FileUtils.getScriptPath(accessionDetailsMap, format),accessionDetailsMap.getAccessionField(), format, location);
+        verify(emailService, times(1)).sendEmailForFastqSubmitted(emailId, 3, 0,
+                FileUtils.getScriptPath(accessionDetailsMap, format), accessionDetailsMap.getAccessionField(), format, location);
 
     }
 
     private List<FileDetail> createFileDetailFtp() {
         List<FileDetail> fileDetailList = new ArrayList<>();
-        FileDetail fileDetail1 = new FileDetail("SRX2000905","SRR4000583","ftp.sra.ebi.ac.uk/vol1/fastq/SRR400/003/SRR4000583/SRR4000583.fastq.gz",
-                1174738707L,"a991ce890047ffca760c6de2617b5fec",true);
-        FileDetail fileDetail2 = new FileDetail("SRX6415696","SRR9654360","ftp.sra.ebi.ac.uk/vol1/fastq/SRR965/000/SRR9654360/SRR9654360.fastq.gz",
-                14139836L,"f3611f35a977b8b82a7adcf0a28c397d",true);
-        FileDetail fileDetail3 = new FileDetail("SRX6415695","SRR9654361","ftp.sra.ebi.ac.uk/vol1/fastq/SRR965/001/SRR9654361/SRR9654361.fastq.gz",
-                15541843L,"1236b79cd93a63289841765aabacb880",true);
+        FileDetail fileDetail1 = new FileDetail("SRX2000905", "SRR4000583", "ftp.sra.ebi.ac.uk/vol1/fastq/SRR400/003/SRR4000583/SRR4000583.fastq.gz",
+                1174738707L, "a991ce890047ffca760c6de2617b5fec", true);
+        FileDetail fileDetail2 = new FileDetail("SRX6415696", "SRR9654360", "ftp.sra.ebi.ac.uk/vol1/fastq/SRR965/000/SRR9654360/SRR9654360.fastq.gz",
+                14139836L, "f3611f35a977b8b82a7adcf0a28c397d", true);
+        FileDetail fileDetail3 = new FileDetail("SRX6415695", "SRR9654361", "ftp.sra.ebi.ac.uk/vol1/fastq/SRR965/001/SRR9654361/SRR9654361.fastq.gz",
+                15541843L, "1236b79cd93a63289841765aabacb880", true);
         fileDetailList.add(fileDetail1);
         fileDetailList.add(fileDetail2);
         fileDetailList.add(fileDetail3);

--- a/src/test/java/uk/ac/ebi/ena/backend/EnaPortalServiceTest.java
+++ b/src/test/java/uk/ac/ebi/ena/backend/EnaPortalServiceTest.java
@@ -24,7 +24,6 @@ import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
 
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;

--- a/src/test/java/uk/ac/ebi/ena/backend/FileDownloaderClientTest.java
+++ b/src/test/java/uk/ac/ebi/ena/backend/FileDownloaderClientTest.java
@@ -1,5 +1,6 @@
 package uk.ac.ebi.ena.backend;
 
+import org.junit.Assert;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -11,7 +12,7 @@ import uk.ac.ebi.ena.app.menu.enums.AccessionTypeEnum;
 import uk.ac.ebi.ena.app.menu.enums.DownloadFormatEnum;
 import uk.ac.ebi.ena.backend.dto.FileDetail;
 import uk.ac.ebi.ena.backend.enums.FileDownloadStatus;
-import uk.ac.ebi.ena.backend.service.FileDownloaderService;
+import uk.ac.ebi.ena.backend.service.FileDownloaderClient;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -21,34 +22,34 @@ import java.util.concurrent.Executors;
 
 @ExtendWith(MockitoExtension.class)
 @RunWith(MockitoJUnitRunner.class)
-public class FileDownloaderServiceTest {
+public class FileDownloaderClientTest {
 
     private final static String downloadFolderPath = "downloads/";
 
     @InjectMocks
-    FileDownloaderService fileDownloaderService;
+    FileDownloaderClient fileDownloaderClient;
 
     @Disabled
     @Test
-    public void testStartDownload_UsingFtp() throws ExecutionException, InterruptedException {
+    public void testStartDownload_UsingAspera() throws ExecutionException, InterruptedException {
         //ARRANGE
         ExecutorService executorService = Executors.newSingleThreadExecutor();
         List<FileDetail> fileDetailList = new ArrayList<>();
-        FileDetail fileDetail = createFileDetailFtp();
+        FileDetail fileDetail = createFileDetailAspera();
         fileDetailList.add(fileDetail);
-
+        String asperaLocation = "C:\\Users\\suman\\AppData\\Local\\Programs\\Aspera\\Aspera Connect\\";//local aspera connect folder
         DownloadFormatEnum format = DownloadFormatEnum.READS_FASTQ;
         int set = 1;
         //ACT
-        FileDownloadStatus fileDownloadStatus = fileDownloaderService.
-                startDownload(executorService, fileDetailList, downloadFolderPath, AccessionTypeEnum.EXPERIMENT, format,
-                        set).get();
-        System.out.println(fileDownloadStatus);
+        FileDownloadStatus fileDownloadStatus = fileDownloaderClient.startDownloadAspera
+                (executorService, fileDetailList, asperaLocation, downloadFolderPath, AccessionTypeEnum.EXPERIMENT, format, set).get();
+        //ASSERT
+        Assert.assertEquals(1, fileDownloadStatus.getSuccesssful());
 
     }
 
-    private FileDetail createFileDetailFtp() {
-        return new FileDetail("SRX7264284", "SRR10583966", "ftp.sra.ebi.ac.uk/vol1/fastq/SRR105/066/SRR10583966/SRR10583966_1.fastq.gz",
+    private FileDetail createFileDetailAspera() {
+        return new FileDetail("SRX7264284", "SRR10583966", "fasp.sra.ebi.ac.uk:/vol1/fastq/SRR105/066/SRR10583966/SRR10583966_1.fastq.gz",
                 6424881L, "59383f5b12bbebc361eadd5ccc1ddaca",false);
     }
 }

--- a/src/test/java/uk/ac/ebi/ena/backend/FileDownloaderClientTest.java
+++ b/src/test/java/uk/ac/ebi/ena/backend/FileDownloaderClientTest.java
@@ -50,6 +50,6 @@ public class FileDownloaderClientTest {
 
     private FileDetail createFileDetailAspera() {
         return new FileDetail("SRX7264284", "SRR10583966", "fasp.sra.ebi.ac.uk:/vol1/fastq/SRR105/066/SRR10583966/SRR10583966_1.fastq.gz",
-                6424881L, "59383f5b12bbebc361eadd5ccc1ddaca",false);
+                6424881L, "59383f5b12bbebc361eadd5ccc1ddaca", false);
     }
 }

--- a/src/test/java/uk/ac/ebi/ena/backend/FileDownloaderServiceTest.java
+++ b/src/test/java/uk/ac/ebi/ena/backend/FileDownloaderServiceTest.java
@@ -49,6 +49,6 @@ public class FileDownloaderServiceTest {
 
     private FileDetail createFileDetailFtp() {
         return new FileDetail("SRX7264284", "SRR10583966", "ftp.sra.ebi.ac.uk/vol1/fastq/SRR105/066/SRR10583966/SRR10583966_1.fastq.gz",
-                6424881L, "59383f5b12bbebc361eadd5ccc1ddaca",false);
+                6424881L, "59383f5b12bbebc361eadd5ccc1ddaca", false);
     }
 }


### PR DESCRIPTION
Test case fixes
Tested locally and on the cluster for different accessions(by providing comma separated list and accession file) including FTP and Aspera downloads